### PR TITLE
[FEAT] 카카오 로그인 및 유저 관련 API

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,6 +12,15 @@ if (localPropertiesFile.exists()) {
     }
 }
 
+// .env 파일에서 카카오 키 읽기
+def envProperties = new Properties()
+def envPropertiesFile = rootProject.file('../.env')
+if (envPropertiesFile.exists()) {
+    envPropertiesFile.withReader('UTF-8') { reader ->
+        envProperties.load(reader)
+    }
+}
+
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
     flutterVersionCode = '1'
@@ -49,6 +58,12 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        
+        // 카카오 키를 Manifest Placeholder로 설정
+        manifestPlaceholders = [
+            KAKAO_NATIVE_APP_KEY: envProperties.getProperty('KAKAO_NATIVE_APP_KEY', ''),
+            applicationName: "android.app.Application"
+        ]
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,21 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        
+        <!-- 카카오 로그인 (Flutter SDK) -->
+        <activity 
+            android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"
+            android:exported="true">
+            <intent-filter android:label="flutter_web_auth">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: kakao${NATIVE_APP_KEY}://oauth -->
+                <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth"/>
+            </intent-filter>
+        </activity>
+        
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,21 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 </dict>
 </plist>

--- a/lib/core/api/api_interceptor.dart
+++ b/lib/core/api/api_interceptor.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'api_exceptions.dart';
+import '../../features/auth/services/token_storage.dart';
 
 /// API 인터셉터
 /// - 요청/응답 로깅
@@ -8,11 +9,18 @@ import 'api_exceptions.dart';
 /// - 에러 처리
 class ApiInterceptor extends Interceptor {
   @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    // 여기에 인증 토큰 추가 등을 구현할 수 있습니다
-    // final token = tokenStorage.getToken();
-    // options.headers['Authorization'] = 'Bearer $token';
-    
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+    // JWT 토큰을 헤더에 자동 추가
+    try {
+      // TokenStorage import 필요
+      // import '../../features/auth/services/token_storage.dart';
+      final token = await TokenStorage.getAccessToken();
+      if (token != null && token.isNotEmpty) {
+        options.headers['Authorization'] = 'Bearer $token';
+      }
+    } catch (e) {
+      // 토큰 가져오기 실패 시 무시
+    }
     // 디버그용 로깅 (프로덕션에서는 제거하거나 로거 사용)
     if (kDebugMode) {
       // print('REQUEST[${options.method}] => PATH: ${options.path}');

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,7 +1,7 @@
 /// 앱 전역 설정
 class AppConfig {
   /// API Base URL
-  static const String baseUrl = 'https://api.example.com';
+  static const String baseUrl = 'http://54.180.159.5:8080';
 
   /// 앱 버전
   static const String appVersion = '1.0.0';

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,7 +1,7 @@
 /// 앱 전역 설정
 class AppConfig {
   /// API Base URL
-  static const String baseUrl = 'http://54.180.159.5:8080';
+  static const String baseUrl = 'http://54.116.30.205:8080';
 
   /// 앱 버전
   static const String appVersion = '1.0.0';

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,9 +1,12 @@
 /// 앱 전역 설정
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+/// 앱 전역 설정
 class AppConfig {
   /// API Base URL
-  static const String baseUrl = 'http://54.116.30.205:8080';
+  static String get baseUrl => dotenv.env['API_BASE_URL'] ?? '';
 
   /// 앱 버전
-  static const String appVersion = '1.0.0';
+  static String get appVersion => dotenv.env['APP_VERSION'] ?? '';
 }
 

--- a/lib/features/auth/models/auth_models.dart
+++ b/lib/features/auth/models/auth_models.dart
@@ -1,3 +1,4 @@
+// API 공통 응답 모델
 class ApiResponse {
   final bool isSuccess;
   final String code;

--- a/lib/features/auth/models/auth_models.dart
+++ b/lib/features/auth/models/auth_models.dart
@@ -1,3 +1,25 @@
+class ApiResponse {
+  final bool isSuccess;
+  final String code;
+  final String message;
+  final Map<String, dynamic>? data;
+
+  ApiResponse({
+    required this.isSuccess,
+    required this.code,
+    required this.message,
+    required this.data,
+  });
+
+  factory ApiResponse.fromJson(Map<String, dynamic> json) {
+    return ApiResponse(
+      isSuccess: json['isSuccess'] ?? false,
+      code: json['code'] ?? '',
+      message: json['message'] ?? '',
+      data: json['data'],
+    );
+  }
+}
 /// 카카오 모바일 로그인 요청 모델
 class KakaoMobileLoginRequest {
   final String accessToken;

--- a/lib/features/auth/models/auth_models.dart
+++ b/lib/features/auth/models/auth_models.dart
@@ -1,0 +1,52 @@
+/// 카카오 모바일 로그인 요청 모델
+class KakaoMobileLoginRequest {
+  final String accessToken;
+
+  KakaoMobileLoginRequest({required this.accessToken});
+
+  Map<String, dynamic> toJson() => {
+        'accessToken': accessToken,
+      };
+}
+
+/// 로그인 결과 응답 모델
+class LoginResponse {
+  final bool isSuccess;
+  final String code;
+  final String message;
+  final LoginData? data;
+
+  LoginResponse({
+    required this.isSuccess,
+    required this.code,
+    required this.message,
+    this.data,
+  });
+
+  factory LoginResponse.fromJson(Map<String, dynamic> json) {
+    return LoginResponse(
+      isSuccess: json['isSuccess'] ?? false,
+      code: json['code'] ?? '',
+      message: json['message'] ?? '',
+      data: json['data'] != null ? LoginData.fromJson(json['data']) : null,
+    );
+  }
+}
+
+/// 로그인 데이터 (토큰)
+class LoginData {
+  final String accessToken;
+  final String refreshToken;
+
+  LoginData({
+    required this.accessToken,
+    required this.refreshToken,
+  });
+
+  factory LoginData.fromJson(Map<String, dynamic> json) {
+    return LoginData(
+      accessToken: json['accessToken'] ?? '',
+      refreshToken: json['refreshToken'] ?? '',
+    );
+  }
+}

--- a/lib/features/auth/providers/user_info_provider.dart
+++ b/lib/features/auth/providers/user_info_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class UserInfo {
+  final int kakaoId;
+  final String nickname;
+  final String profileImg;
+  final String level;
+  final int stampCount;
+
+  UserInfo({
+    required this.kakaoId,
+    required this.nickname,
+    required this.profileImg,
+    required this.level,
+    required this.stampCount,
+  });
+
+  factory UserInfo.fromJson(Map<String, dynamic> json) {
+    return UserInfo(
+      kakaoId: json['kakaoId'] ?? 0,
+      nickname: json['nickname'] ?? '',
+      profileImg: json['profileImg'] ?? '',
+      level: json['level'] ?? '',
+      stampCount: json['stampCount'] ?? 0,
+    );
+  }
+}
+
+final userInfoProvider = StateProvider<UserInfo?>((ref) => null);

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -4,15 +4,17 @@ import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import '../services/auth_service.dart';
 import '../services/token_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/user_info_provider.dart';
 
-class LoginScreen extends StatefulWidget {
+class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
   @override
-  State<LoginScreen> createState() => _LoginScreenState();
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
 }
 
-class _LoginScreenState extends State<LoginScreen> {
+class _LoginScreenState extends ConsumerState<LoginScreen> {
   final AuthService _authService = AuthService();
   bool _isLoading = false;
 
@@ -42,7 +44,20 @@ class _LoginScreenState extends State<LoginScreen> {
         );
         print('JWT 토큰 저장 완료');
 
-        // 5. 온보딩 화면으로 이동
+        // 5. JWT 토큰으로 유저 정보 조회
+        try {
+          // Dio 인스턴스에 JWT 토큰 세팅 필요 (생략 시 기존 AuthService 활용)
+          final userInfoResponse = await _authService.getUserInfo();
+          if (userInfoResponse.isSuccess && userInfoResponse.data != null) {
+            final userInfo = UserInfo.fromJson(userInfoResponse.data!);
+            ref.read(userInfoProvider.notifier).state = userInfo;
+            print('유저 정보 저장 완료: ${userInfo.nickname}');
+          }
+        } catch (e) {
+          print('유저 정보 조회 실패: $e');
+        }
+
+        // 6. 온보딩 화면으로 이동
         if (mounted) {
           context.go('/onboarding');
         }

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,9 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
+import '../services/auth_service.dart';
+import '../services/token_storage.dart';
 
-class LoginScreen extends StatelessWidget {
+class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final AuthService _authService = AuthService();
+  bool _isLoading = false;
+
+  // 카카오 웹뷰 로그인
+  Future<void> _loginWithKakao() async {
+    if (_isLoading) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      // 1. 카카오 로그인 (웹뷰)
+      OAuthToken kakaoToken = await UserApi.instance.loginWithKakaoAccount();
+      print('카카오 로그인 성공 - 토큰: ${kakaoToken.accessToken}');
+
+      // 2. 사용자 정보 가져오기 (선택사항, 디버깅용)
+      User user = await UserApi.instance.me();
+      print('사용자 정보: ${user.kakaoAccount?.profile?.nickname}');
+
+      // 3. 백엔드에 카카오 액세스 토큰 전송 및 JWT 토큰 받기
+      final loginResponse = await _authService.kakaoMobileLogin(kakaoToken.accessToken);
+
+      if (loginResponse.isSuccess && loginResponse.data != null) {
+        // 4. JWT 토큰 저장
+        await TokenStorage.saveTokens(
+          accessToken: loginResponse.data!.accessToken,
+          refreshToken: loginResponse.data!.refreshToken,
+        );
+        print('JWT 토큰 저장 완료');
+
+        // 5. 온보딩 화면으로 이동
+        if (mounted) {
+          context.go('/onboarding');
+        }
+      } else {
+        throw Exception(loginResponse.message);
+      }
+    } catch (error) {
+      print('로그인 실패: $error');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('로그인에 실패했습니다. 다시 시도해주세요.\n$error'),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,25 +104,32 @@ class LoginScreen extends StatelessWidget {
                 width: double.infinity,
                 height: 48,
                 child: ElevatedButton(
-                  onPressed: () {
-                    // TODO: 추후 실제 카카오 로그인 연동
-                    context.go('/onboarding');
-                  },
+                  onPressed: _isLoading ? null : _loginWithKakao,
                   style: ElevatedButton.styleFrom(
                     elevation: 0,
-                    backgroundColor: const Color(0xFFFEE500), // 카카오 옐로우
+                    backgroundColor: const Color(0xFFFEE500),
                     foregroundColor: AppColors.black,
+                    disabledBackgroundColor: const Color(0xFFFEE500).withOpacity(0.5),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
-                  child: const Text(
-                    '카카오 계정으로 로그인하기',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
+                  child: _isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(AppColors.black),
+                          ),
+                        )
+                      : const Text(
+                          '카카오 계정으로 로그인하기',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
                 ),
               ),
             ),

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -6,6 +6,7 @@ import '../services/auth_service.dart';
 import '../services/token_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/user_info_provider.dart';
+import 'package:plogo/features/home/services/recommend_service.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
@@ -46,7 +47,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
         // 5. JWT 토큰으로 유저 정보 조회
         try {
-          // Dio 인스턴스에 JWT 토큰 세팅 필요 (생략 시 기존 AuthService 활용)
           final userInfoResponse = await _authService.getUserInfo();
           if (userInfoResponse.isSuccess && userInfoResponse.data != null) {
             final userInfo = UserInfo.fromJson(userInfoResponse.data!);
@@ -57,9 +57,26 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           print('유저 정보 조회 실패: $e');
         }
 
-        // 6. 온보딩 화면으로 이동
-        if (mounted) {
-          context.go('/onboarding');
+        // 6. 추천 코스 조회 후 온보딩/홈 분기
+        try {
+          final recommendService = RecommendService();
+          final recommendResponse = await recommendService.getRecommendedCourses();
+          print('[추천코스 API] isSuccess: [32m${recommendResponse.isSuccess}[0m');
+          print('[추천코스 API] code: ${recommendResponse.code}');
+          print('[추천코스 API] message: ${recommendResponse.message}');
+          print('[추천코스 API] data.length: [36m${recommendResponse.data.length}[0m');
+          print('[추천코스 API] data: ${recommendResponse.data}');
+          if (recommendResponse.isSuccess && recommendResponse.data.isNotEmpty) {
+            print('[분기] 홈으로 이동');
+            if (mounted) context.go('/home');
+          } else {
+            print('[분기] 온보딩으로 이동');
+            if (mounted) context.go('/onboarding');
+          }
+        } catch (e) {
+          print('[추천코스 API] 예외 발생: $e');
+          print('[분기] 온보딩으로 이동');
+          if (mounted) context.go('/onboarding');
         }
       } else {
         throw Exception(loginResponse.message);

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+import '../../../core/api/api_client.dart';
+import '../models/auth_models.dart';
+
+/// 인증 관련 API 서비스
+class AuthService {
+  final Dio _dio = apiClient.dio;
+
+  /// 카카오 모바일 로그인
+  Future<LoginResponse> kakaoMobileLogin(String kakaoAccessToken) async {
+    try {
+      print('백엔드 API 호출 시작: /user/kakao/login/app');
+      print('카카오 토큰: ${kakaoAccessToken.substring(0, 20)}...');
+
+      // Query 파라미터로 accessToken 전송
+      final response = await _dio.post(
+        '/user/kakao/login/app',
+        queryParameters: {
+          'accessToken': kakaoAccessToken,
+        },
+      );
+
+      print('백엔드 응답 성공: ${response.statusCode}');
+      print('응답 데이터: ${response.data}');
+
+      return LoginResponse.fromJson(response.data);
+    } on DioException catch (e) {
+      print('DioException 발생!');
+      print('에러 타입: ${e.type}');
+      print('상태 코드: ${e.response?.statusCode}');
+      print('에러 메시지: ${e.message}');
+      print('응답 데이터: ${e.response?.data}');
+      throw Exception('카카오 로그인 실패: ${e.message}');
+    } catch (e) {
+      print('알 수 없는 에러: $e');
+      throw Exception('카카오 로그인 실패: $e');
+    }
+  }
+}

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -4,6 +4,20 @@ import '../models/auth_models.dart';
 
 /// 인증 관련 API 서비스
 class AuthService {
+  /// 유저 정보 조회
+  Future<ApiResponse> getUserInfo() async {
+    try {
+      final response = await _dio.get('/user/info');
+      print('유저 정보 응답: ${response.data}');
+      return ApiResponse.fromJson(response.data);
+    } on DioException catch (e) {
+      print('유저 정보 DioException: ${e.message}');
+      throw Exception('유저 정보 조회 실패: ${e.message}');
+    } catch (e) {
+      print('유저 정보 알 수 없는 에러: $e');
+      throw Exception('유저 정보 조회 실패: $e');
+    }
+  }
   final Dio _dio = apiClient.dio;
 
   /// 카카오 모바일 로그인

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -8,13 +8,12 @@ class AuthService {
   Future<ApiResponse> getUserInfo() async {
     try {
       final response = await _dio.get('/user/info');
-      print('유저 정보 응답: ${response.data}');
       return ApiResponse.fromJson(response.data);
     } on DioException catch (e) {
-      print('유저 정보 DioException: ${e.message}');
+      print('유저 정보 조회 실패: ${e.message}');
       throw Exception('유저 정보 조회 실패: ${e.message}');
     } catch (e) {
-      print('유저 정보 알 수 없는 에러: $e');
+      print('유저 정보 조회 실패: $e');
       throw Exception('유저 정보 조회 실패: $e');
     }
   }
@@ -23,30 +22,18 @@ class AuthService {
   /// 카카오 모바일 로그인
   Future<LoginResponse> kakaoMobileLogin(String kakaoAccessToken) async {
     try {
-      print('백엔드 API 호출 시작: /user/kakao/login/app');
-      print('카카오 토큰: ${kakaoAccessToken.substring(0, 20)}...');
-
-      // Query 파라미터로 accessToken 전송
       final response = await _dio.post(
         '/user/kakao/login/app',
         queryParameters: {
           'accessToken': kakaoAccessToken,
         },
       );
-
-      print('백엔드 응답 성공: ${response.statusCode}');
-      print('응답 데이터: ${response.data}');
-
       return LoginResponse.fromJson(response.data);
     } on DioException catch (e) {
-      print('DioException 발생!');
-      print('에러 타입: ${e.type}');
-      print('상태 코드: ${e.response?.statusCode}');
-      print('에러 메시지: ${e.message}');
-      print('응답 데이터: ${e.response?.data}');
+      print('카카오 로그인 실패: ${e.message}');
       throw Exception('카카오 로그인 실패: ${e.message}');
     } catch (e) {
-      print('알 수 없는 에러: $e');
+      print('카카오 로그인 실패: $e');
       throw Exception('카카오 로그인 실패: $e');
     }
   }

--- a/lib/features/auth/services/token_storage.dart
+++ b/lib/features/auth/services/token_storage.dart
@@ -1,0 +1,57 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 토큰 저장 및 관리 서비스
+class TokenStorage {
+  static const String _accessTokenKey = 'access_token';
+  static const String _refreshTokenKey = 'refresh_token';
+
+  /// 액세스 토큰 저장
+  static Future<void> saveAccessToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_accessTokenKey, token);
+  }
+
+  /// 리프레시 토큰 저장
+  static Future<void> saveRefreshToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_refreshTokenKey, token);
+  }
+
+  /// 토큰 한 번에 저장
+  static Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    await Future.wait([
+      saveAccessToken(accessToken),
+      saveRefreshToken(refreshToken),
+    ]);
+  }
+
+  /// 액세스 토큰 가져오기
+  static Future<String?> getAccessToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_accessTokenKey);
+  }
+
+  /// 리프레시 토큰 가져오기
+  static Future<String?> getRefreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_refreshTokenKey);
+  }
+
+  /// 토큰 삭제 (로그아웃)
+  static Future<void> clearTokens() async {
+    final prefs = await SharedPreferences.getInstance();
+    await Future.wait([
+      prefs.remove(_accessTokenKey),
+      prefs.remove(_refreshTokenKey),
+    ]);
+  }
+
+  /// 로그인 여부 확인
+  static Future<bool> isLoggedIn() async {
+    final token = await getAccessToken();
+    return token != null && token.isNotEmpty;
+  }
+}

--- a/lib/features/home/models/course_models.dart
+++ b/lib/features/home/models/course_models.dart
@@ -1,0 +1,50 @@
+class CourseRecommendResponse {
+  final bool isSuccess;
+  final String code;
+  final String message;
+  final List<CourseRecommendItem> data;
+
+  CourseRecommendResponse({
+    required this.isSuccess,
+    required this.code,
+    required this.message,
+    required this.data,
+  });
+
+  factory CourseRecommendResponse.fromJson(Map<String, dynamic> json) {
+    return CourseRecommendResponse(
+      isSuccess: json['isSuccess'] ?? false,
+      code: json['code'] ?? '',
+      message: json['message'] ?? '',
+      data: (json['data'] as List<dynamic>? ?? [])
+          .map((e) => CourseRecommendItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class CourseRecommendItem {
+  final int courseId;
+  final String image;
+  final String area;
+  final String name;
+  final bool isSave;
+
+  CourseRecommendItem({
+    required this.courseId,
+    required this.image,
+    required this.area,
+    required this.name,
+    required this.isSave,
+  });
+
+  factory CourseRecommendItem.fromJson(Map<String, dynamic> json) {
+    return CourseRecommendItem(
+      courseId: json['course_id'] ?? 0,
+      image: json['image'] ?? '',
+      area: json['area'] ?? '',
+      name: json['name'] ?? '',
+      isSave: json['isSave'] ?? false,
+    );
+  }
+}

--- a/lib/features/home/services/recommend_service.dart
+++ b/lib/features/home/services/recommend_service.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import '../../../core/api/api_client.dart';
+import '../models/course_models.dart';
+
+/// 추천 코스 관련 API 서비스
+class RecommendService {
+  final Dio _dio = apiClient.dio;
+
+  /// 추천 코스 조회
+  Future<CourseRecommendResponse> getRecommendedCourses() async {
+    try {
+      final response = await _dio.get('/course/recommend');
+      return CourseRecommendResponse.fromJson(response.data);
+    } on DioException catch (e) {
+      throw Exception('추천 코스 조회 실패: ${e.message}');
+    } catch (e) {
+      throw Exception('추천 코스 조회 실패: $e');
+    }
+  }
+}

--- a/lib/features/mypage/screens/mypage_screen.dart
+++ b/lib/features/mypage/screens/mypage_screen.dart
@@ -3,6 +3,10 @@ import 'package:plogo/features/mypage/widgets/profile_header.dart';
 import 'package:plogo/features/mypage/widgets/saved_courses_section.dart';
 import 'package:plogo/features/search/widgets/recent_viewed_courses_section.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
+import 'package:plogo/features/auth/services/token_storage.dart';
+import 'package:plogo/features/mypage/services/mypage_service.dart';
+import 'package:plogo/core/api/api_client.dart';
+import 'package:go_router/go_router.dart';
 
 class MyPageScreen extends StatelessWidget {
 	const MyPageScreen({super.key});
@@ -94,11 +98,22 @@ class MyPageScreen extends StatelessWidget {
 										contentPadding: EdgeInsets.zero,
 										visualDensity: const VisualDensity(horizontal: -2, vertical: -4),
 										title: const Text(
-											'로그아웃',
+											'회원탈퇴',
 											style: TextStyle(fontSize: 14, fontWeight: FontWeight.w400, color: AppColors.grey),
 										),
-										onTap: () {
-											// TODO: 로그아웃 처리
+										onTap: () async {
+											// 회원탈퇴 API 호출
+											final service = MyPageService(apiClient.dio);
+											try {
+												final response = await service.withdraw();
+												print('[회원탈퇴] 성공: ${response.isSuccess}, code: ${response.code}, message: ${response.message}');
+											} catch (e) {
+												print('[회원탈퇴] 실패: $e');
+											}
+											// 토큰 삭제
+											await TokenStorage.clearTokens();
+											// 스플래시로 이동
+											context.go('/splash');
 										},
 									),
 								],

--- a/lib/features/mypage/services/mypage_service.dart
+++ b/lib/features/mypage/services/mypage_service.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+import 'package:plogo/features/auth/services/token_storage.dart';
+import 'package:plogo/features/auth/models/auth_models.dart';
+
+/// 마이페이지 관련 API 서비스
+class MyPageService {
+  final Dio _dio;
+  MyPageService(this._dio);
+
+  /// 회원탈퇴(로그아웃) API 호출
+  Future<ApiResponse> withdraw() async {
+    final accessToken = await TokenStorage.getAccessToken();
+    try {
+      final response = await _dio.delete(
+        '/user/withdraw',
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+          },
+        ),
+      );
+      return ApiResponse.fromJson(response.data);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/features/onboarding/providers/onboarding_provider.dart
+++ b/lib/features/onboarding/providers/onboarding_provider.dart
@@ -55,10 +55,13 @@ class OnboardingNotifier extends Notifier<List<List<String>>> {
     try {
       final response = await dio.post('/course/analyze', data: body);
       final isSuccess = response.data['isSuccess'] == true;
-      debugPrint('API 응답: ${response.data}');
+      debugPrint('[선호도 저장 API] 응답: ${response.data}');
+      debugPrint('[선호도 저장 API] isSuccess: $isSuccess');
+      debugPrint('[선호도 저장 API] code: ${response.data['code']}');
+      debugPrint('[선호도 저장 API] message: ${response.data['message']}');
       return isSuccess;
     } catch (e) {
-      debugPrint('API 오류: $e');
+      debugPrint('[선호도 저장 API] 오류: $e');
       return false;
     }
   }

--- a/lib/features/onboarding/providers/onboarding_provider.dart
+++ b/lib/features/onboarding/providers/onboarding_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
 import '../data/models/onboarding_step.dart';
 
 class OnboardingNotifier extends Notifier<List<List<String>>> {
@@ -49,9 +50,26 @@ class OnboardingNotifier extends Notifier<List<List<String>>> {
     state = newState;
   }
 
-  void submit() {
-    debugPrint('Selected: $state');
+  Future<bool> submit(Dio dio) async {
+    final body = toApiRequestBody();
+    try {
+      final response = await dio.post('/course/analyze', data: body);
+      final isSuccess = response.data['isSuccess'] == true;
+      debugPrint('API 응답: ${response.data}');
+      return isSuccess;
+    } catch (e) {
+      debugPrint('API 오류: $e');
+      return false;
+    }
   }
+
+    Map<String, List<String>> toApiRequestBody() {
+      return {
+        "firstKeyword": state[0],
+        "secondKeyword": state[1],
+        "thirdKeyword": state[2],
+      };
+    }
 }
 
 final onboardingProvider = NotifierProvider<OnboardingNotifier, List<List<String>>>(

--- a/lib/features/onboarding/screens/onboarding_complete_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_complete_screen.dart
@@ -4,24 +4,24 @@ import 'package:go_router/go_router.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:plogo/shared/widgets/loading_indicator.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+// 예시: 닉네임 Provider (실제 프로젝트에 맞게 수정 필요)
+final nicknameProvider = Provider<String>((ref) => '닉네임');
 
-class OnboardingCompleteScreen extends StatefulWidget {
+class OnboardingCompleteScreen extends ConsumerStatefulWidget {
   const OnboardingCompleteScreen({super.key});
 
   @override
-  State<OnboardingCompleteScreen> createState() =>
-      _OnboardingCompleteScreenState();
+  ConsumerState<OnboardingCompleteScreen> createState() => _OnboardingCompleteScreenState();
 }
 
-class _OnboardingCompleteScreenState extends State<OnboardingCompleteScreen> {
+class _OnboardingCompleteScreenState extends ConsumerState<OnboardingCompleteScreen> {
   bool isLoading = true;
 
   @override
   void initState() {
     super.initState();
-
-    // 로딩 (API 연결 후 Dio.post() 추가)
     Future.delayed(const Duration(seconds: 2), () {
       if (mounted) {
         setState(() {
@@ -33,70 +33,71 @@ class _OnboardingCompleteScreenState extends State<OnboardingCompleteScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final nickname = ref.watch(nicknameProvider);
     return Scaffold(
       backgroundColor: Colors.white,
       body: Padding(
         padding: const EdgeInsets.fromLTRB(24, 238, 24, 40),
         child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (isLoading) ...[
-                  const Text(
-                    'ㅇㅇ님께서 좋아하실 만한\n플로깅 코스를 찾고 있어요.',
-                    textAlign: TextAlign.start,
-                    style: TextStyle(fontSize: 24),
-                  ),
-                  const SizedBox(height: 88),
-                  const Center(
-                    child: LineSpinner(
-                      size: 60,
-                      lineCount: 16,
-                      lineLength: 8,
-                      lineWidth: 5,
-                      duration: Duration(milliseconds: 1600),
-                    ),
-                  ),
-                ] else ...[
-                  const Text(
-                    '선택하신 테마를 바탕으로\n플로깅 코스를 추천해드릴게요.',
-                    textAlign: TextAlign.start,
-                    style: TextStyle(fontSize: 24),
-                  ),
-                  const SizedBox(height: 88),
-                  Center(
-                    child: Image.asset(
-                      'assets/images/completed.png',
-                      width: 80,
-                      height: 80,
-                      fit: BoxFit.contain,
-                    ),
-                  ),
-                ],
-                const Spacer(),
-                SizedBox(
-                  width: double.infinity,
-                  height: 50,
-                  child: ElevatedButton(
-                    onPressed: isLoading
-                        ? null
-                        : () {
-                            context.go('/home');
-                          },
-                    style: ElevatedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12)),
-                      backgroundColor:
-                          isLoading ? AppColors.grey : AppColors.primary,
-                    ),
-                    child: const Text(
-                      '시작하기',
-                      style: TextStyle(color: Colors.white, fontSize: 16),
-                    ),
-                  ),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isLoading) ...[
+              Text(
+                '$nickname님께서 좋아하실 만한\n플로깅 코스를 찾고 있어요.',
+                textAlign: TextAlign.start,
+                style: const TextStyle(fontSize: 24),
+              ),
+              const SizedBox(height: 88),
+              const Center(
+                child: LineSpinner(
+                  size: 60,
+                  lineCount: 16,
+                  lineLength: 8,
+                  lineWidth: 5,
+                  duration: Duration(milliseconds: 1600),
                 ),
-              ],
+              ),
+            ] else ...[
+              const Text(
+                '선택하신 테마를 바탕으로\n플로깅 코스를 추천해드릴게요.',
+                textAlign: TextAlign.start,
+                style: TextStyle(fontSize: 24),
+              ),
+              const SizedBox(height: 88),
+              Center(
+                child: Image.asset(
+                  'assets/images/completed.png',
+                  width: 80,
+                  height: 80,
+                  fit: BoxFit.contain,
+                ),
+              ),
+            ],
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: ElevatedButton(
+                onPressed: isLoading
+                    ? null
+                    : () {
+                        context.go('/home');
+                      },
+                style: ElevatedButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12)),
+                  backgroundColor:
+                      isLoading ? AppColors.grey : AppColors.primary,
+                ),
+                child: const Text(
+                  '시작하기',
+                  style: TextStyle(color: Colors.white, fontSize: 16),
+                ),
+              ),
             ),
-          ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/onboarding/screens/onboarding_complete_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_complete_screen.dart
@@ -5,9 +5,7 @@ import 'package:plogo/shared/theme/app_colors.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:plogo/shared/widgets/loading_indicator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-// 예시: 닉네임 Provider (실제 프로젝트에 맞게 수정 필요)
-final nicknameProvider = Provider<String>((ref) => '닉네임');
+import 'package:plogo/features/auth/providers/user_info_provider.dart';
 
 class OnboardingCompleteScreen extends ConsumerStatefulWidget {
   const OnboardingCompleteScreen({super.key});
@@ -33,7 +31,8 @@ class _OnboardingCompleteScreenState extends ConsumerState<OnboardingCompleteScr
 
   @override
   Widget build(BuildContext context) {
-    final nickname = ref.watch(nicknameProvider);
+    final userInfo = ref.watch(userInfoProvider);
+    final nickname = userInfo?.nickname ?? '회원';
     return Scaffold(
       backgroundColor: Colors.white,
       body: Padding(

--- a/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../providers/onboarding_provider.dart';
 import '../widgets/onboarding_item.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
+import 'package:plogo/core/api/api_client.dart';
 
 class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key});
@@ -89,12 +90,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               height: 50,
               child: ElevatedButton(
                 onPressed: stepSelections.isNotEmpty
-                    ? () {
+                    ? () async {
                   if (currentStep + 1 < OnboardingNotifier.steps.length) {
                     setState(() {
                       currentStep++;
                     });
                   } else {
+                    // 마지막 완료 시 선호도 저장 API 호출
+                    final dio = apiClient.dio;
+                    final isSuccess = await ref.read(onboardingProvider.notifier).submit(dio);
+                    debugPrint('[온보딩 완료] 선호도 저장 결과: $isSuccess');
                     context.go('/onboarding-complete');
                   }
                 }

--- a/lib/features/onboarding/screens/splash_screen.dart
+++ b/lib/features/onboarding/screens/splash_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import 'package:go_router/go_router.dart';
+import 'package:plogo/features/auth/services/token_storage.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -14,11 +15,17 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    // 간단한 지연 후 온보딩으로 이동 (차후 로그인 상태에 따라 분기 가능)
-    Timer(const Duration(milliseconds: 1200), () {
+    // 1.5초 후 토큰 조회 및 분기
+    Timer(const Duration(milliseconds: 1500), () async {
       if (!mounted) return;
-      // TODO: 로그인 상태에 따라 홈/온보딩 분기
-      context.go('/login');
+      final accessToken = await TokenStorage.getAccessToken();
+      if (accessToken != null && accessToken.isNotEmpty) {
+        // 로그인 상태: 홈으로 이동
+        context.go('/home');
+      } else {
+        // 비로그인: 로그인 화면으로 이동
+        context.go('/login');
+      }
     });
   }
 

--- a/lib/features/onboarding/services/onboarding_api_service.dart
+++ b/lib/features/onboarding/services/onboarding_api_service.dart
@@ -1,0 +1,11 @@
+import 'package:dio/dio.dart';
+import '../providers/onboarding_provider.dart';
+
+class OnboardingApiService {
+  final Dio _dio;
+  OnboardingApiService(this._dio);
+
+  Future<Response> analyzeCourse(Map<String, List<String>> body) async {
+    return await _dio.post('/course/analyze', data: body);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_map_plugin/kakao_map_plugin.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'core/router/app_router.dart';
 import 'core/api/api_client.dart';
 import 'shared/theme/app_theme.dart';
@@ -12,7 +13,12 @@ void main() async {
   // 환경 변수 로드
   await dotenv.load(fileName: '.env');
   
-  // 카카오맵 SDK 초기화 (환경 변수에서 키 읽기)
+  // 카카오 로그인 SDK 초기화 (네이티브 앱 키)
+  KakaoSdk.init(
+    nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY'] ?? '',
+  );
+  
+  // 카카오맵 SDK 초기화 (JavaScript 키)
   AuthRepository.initialize(
     appKey: dotenv.env['KAKAO_JS_KEY'] ?? '',
   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
+  asn1lib:
+    dependency: transitive
+    description:
+      name: asn1lib
+      sha256: "9a8f69025044eb466b9b60ef3bc3ac99b4dc6c158ae9c56d25eeccf5bc56d024"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.5"
   async:
     dependency: transitive
     description:
@@ -265,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  encrypt:
+    dependency: transitive
+    description:
+      name: encrypt
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -448,6 +464,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  kakao_flutter_sdk_auth:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_auth
+      sha256: "028d8803b7545cc5f41d20cda43b813683700e45c6c13aa4ca56f4b9c673305c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
+  kakao_flutter_sdk_common:
+    dependency: transitive
+    description:
+      name: kakao_flutter_sdk_common
+      sha256: "1c4944cc50c363d4626e9006ab39ee496c8f5ca602b96154272b90d40544aaca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
+  kakao_flutter_sdk_user:
+    dependency: "direct main"
+    description:
+      name: kakao_flutter_sdk_user
+      sha256: "5157feeafe58d677d314baa5ccdcb435fd9680c485c3b23e9ad7d97a0c93694f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.7+3"
   kakao_map_plugin:
     dependency: "direct main"
     description:
@@ -656,6 +696,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.6.0"
-  analyzer_buffer:
-    dependency: transitive
-    description:
-      name: analyzer_buffer
-      sha256: f7833bee67c03c37241c67f8741b17cc501b69d9758df7a5a4a13ed6c947be43
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.10"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -69,50 +61,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "2.5.4"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "409002f1adeea601018715d613115cfaf0e31f512cb80ae4534c79867ae2363d"
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.5.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
       url: "https://pub.dev"
     source: hosted
-    version: "9.3.1"
+    version: "9.1.2"
   built_collection:
     dependency: transitive
     description:
@@ -169,14 +161,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
-  cli_config:
-    dependency: transitive
-    description:
-      name: cli_config
-      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -209,22 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  coverage:
-    dependency: transitive
-    description:
-      name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -237,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: cc4684d22ca05bf0a4a51127e19a8aea576b42079ed2bc9e956f11aaebe35dd1
+      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.7.5"
   custom_lint_visitor:
     dependency: transitive
     description:
@@ -346,18 +322,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9e2d6907f12cc7d23a846847615941bddee8709bf2bfd274acdf5e80bcf22fde"
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.6.1"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
+      sha256: "055de8921be7b8e8b98a233c7a5ef84b3a6fcc32f46f1ebf5b9bb3576d108355"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -412,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -568,30 +544,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mockito:
-    dependency: transitive
-    description:
-      name: mockito
-      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.5.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  node_preamble:
-    dependency: transitive
-    description:
-      name: node_preamble
-      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   octo_image:
     dependency: transitive
     description:
@@ -712,14 +664,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -740,34 +684,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: c406de02bff19d920b832bddfb8283548bfa05ce41c59afba57ce643e116aa59
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.6.1"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: a0f68adb078b790faa3c655110a017f9a7b7b079a57bbd40f540e80dce5fcd29
+      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.7"
+    version: "0.5.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "7230014155777fc31ba3351bc2cb5a3b5717b11bfafe52b1553cb47d385f8897"
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.6.1"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "49894543a42cf7a9954fc4e7366b6d3cb2e6ec0fa07775f660afcdd92d097702"
+      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.6.5"
   rxdart:
     dependency: transitive
     description:
@@ -840,22 +784,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
-  shelf_packages_handler:
-    dependency: transitive
-    description:
-      name: shelf_packages_handler
-      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  shelf_static:
-    dependency: transitive
-    description:
-      name: shelf_static
-      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -873,26 +801,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
-  source_map_stack_trace:
-    dependency: transitive
-    description:
-      name: source_map_stack_trace
-      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  source_maps:
-    dependency: transitive
-    description:
-      name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.13"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
@@ -901,14 +813,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
-  sprintf:
-    dependency: transitive
-    description:
-      name: sprintf
-      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   sqflite:
     dependency: transitive
     description:
@@ -1005,14 +909,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  test:
-    dependency: transitive
-    description:
-      name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
@@ -1021,14 +917,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
-  test_core:
-    dependency: transitive
-    description:
-      name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.11"
   timing:
     dependency: transitive
     description:
@@ -1049,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.5.2"
   vector_graphics:
     dependency: transitive
     description:
@@ -1125,14 +1013,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   webview_flutter:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.7
-  provider: ^6.1.2
+  # provider: ^6.1.2
   go_router: ^16.3.0
   dio: ^5.4.3+1
   shared_preferences: ^2.2.3
@@ -40,8 +40,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  flutter_riverpod: ^3.0.3
-  riverpod_annotation: ^3.0.3
+  flutter_riverpod: ^2.5.1
+  riverpod_annotation: ^2.3.5
   kakao_map_plugin: ^0.3.7
   flutter_dotenv: ^5.1.0
   kakao_flutter_sdk_user: ^1.9.7+3
@@ -56,7 +56,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
-  riverpod_generator: ^3.0.3
+  riverpod_generator: ^2.3.5
   build_runner: ^2.4.9
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   riverpod_annotation: ^3.0.3
   kakao_map_plugin: ^0.3.7
   flutter_dotenv: ^5.1.0
+  kakao_flutter_sdk_user: ^1.9.7+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 카카오 회원가입 및 로그인
- 회원 탈퇴
- 로그인, 회원가입 상태 및 선호도 저장 여부에 따른 화면 분기 로직 구현

### 🤔 추후 작업 예정
- 유저 관련 api 는 완료!
- 홈화면에 유저 정보에 따른 api 연동해야함

### 📸 작업 결과 (스크린샷)
<img width="979" height="243" alt="image" src="https://github.com/user-attachments/assets/6d3f461b-f95d-4c7c-bc1a-2f09e515b05e" />


### 🔗 관련 이슈
- close: #5 