### PR TITLE
[FEAT] 검색 화면 API 연동

### DIFF
--- a/lib/features/region/screens/sigungu_course_list_screen.dart
+++ b/lib/features/region/screens/sigungu_course_list_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:plogo/shared/theme/app_colors.dart';
+import 'package:plogo/features/region/services/sigungu_course_service.dart';
+import 'package:plogo/features/home/models/course_models.dart';
+import 'package:plogo/shared/widgets/course_list_view.dart';
+import 'package:plogo/features/detail/screens/course_detail_screen.dart';
+
+class SigunguCourseListScreen extends StatefulWidget {
+  final String regionName;
+  final int sigunguId;
+  const SigunguCourseListScreen({super.key, required this.regionName, required this.sigunguId});
+
+  @override
+  State<SigunguCourseListScreen> createState() => _SigunguCourseListScreenState();
+}
+
+class _SigunguCourseListScreenState extends State<SigunguCourseListScreen> {
+  late Future<CourseRecommendResponse> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = SigunguCourseService().getCoursesBySigungu(widget.sigunguId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, size: 28),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text(widget.regionName, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+        centerTitle: false,
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        titleSpacing: 4,
+      ),
+      body: FutureBuilder<CourseRecommendResponse>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('코스 불러오기 실패'));
+          }
+          final courses = snapshot.data?.data ?? [];
+          if (courses.isEmpty) {
+            return const Center(child: Text('해당 지역의 코스가 없습니다.'));
+          }
+          return CourseListView(
+            title: widget.regionName,
+            courses: courses,
+            onCardTap: (courseId, name) async {
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => CourseDetailScreen(
+                    courseId: courseId,
+                    title: name,
+                  ),
+                ),
+              );
+              setState(() {
+                _future = SigunguCourseService().getCoursesBySigungu(widget.sigunguId);
+              });
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/region/services/sigungu_course_service.dart
+++ b/lib/features/region/services/sigungu_course_service.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+import '../../../core/api/api_client.dart';
+import '../../home/models/course_models.dart';
+
+class SigunguCourseService {
+  final Dio _dio = apiClient.dio;
+
+  Future<CourseRecommendResponse> getCoursesBySigungu(int sigunguId) async {
+    try {
+      final response = await _dio.get('/course/sigungu/$sigunguId');
+      return CourseRecommendResponse.fromJson(response.data);
+    } catch (e) {
+      throw Exception('시군구 코스 조회 실패: $e');
+    }
+  }
+}

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:plogo/features/search/services/search_service.dart';
+import 'package:plogo/features/search/services/search_api_service.dart';
+import 'package:plogo/features/mypage/services/mypage_service.dart';
+import 'package:plogo/core/api/api_client.dart';
+
+final searchQueryProvider = StateProvider<String>((ref) => '');
+
+final recentKeywordsProvider = FutureProvider<List<String>>((ref) async {
+  return SearchService(apiClient.dio).getRecentKeywords();
+});
+
+final recentCoursesProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
+  return MyPageService(apiClient.dio).getRecentCourses();
+});
+
+final regionResultsProvider = FutureProvider.family<List<Map<String, dynamic>>, String>((ref, query) async {
+  if (query.isEmpty) return [];
+  final regions = await SearchApiService(apiClient.dio).getSigunguList();
+  return regions.where((r) => r['sigunguName']?.toString().contains(query) ?? false).toList();
+});
+
+final courseResultsProvider = FutureProvider.family<List<Map<String, dynamic>>, String>((ref, query) async {
+  if (query.isEmpty) return [];
+  return SearchApiService(apiClient.dio).searchCourses(query);
+});

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -11,6 +11,7 @@ import 'package:plogo/core/api/api_client.dart';
 import 'package:plogo/features/mypage/services/mypage_service.dart';
 import 'package:plogo/features/search/services/search_service.dart';
 import 'package:plogo/features/search/services/search_api_service.dart';
+import 'package:go_router/go_router.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({Key? key}) : super(key: key);
@@ -37,6 +38,13 @@ class _SearchScreenState extends State<SearchScreen> {
     });
     _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
     _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 검색화면이 다시 보일 때마다 최근 코스 Future 갱신
+    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
   }
 
   @override
@@ -171,7 +179,15 @@ class _SearchScreenState extends State<SearchScreen> {
                 );
               }
               final items = snapshot.data ?? <Map<String, dynamic>>[];
-              return RecentViewedCoursesSection(items: items);
+              return RecentViewedCoursesSection(
+                items: items,
+                onCardTap: (courseId, name) async {
+                  await context.push('/home/detail/$courseId', extra: name);
+                  setState(() {
+                    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
+                  });
+                },
+              );
             },
           ),
           const SizedBox(height: 32),

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -146,6 +146,11 @@ class _SearchScreenState extends State<SearchScreen> {
               return RecentSearches(
                 keywords: keywords,
                 onDelete: _deleteKeyword,
+                onTap: (keyword) {
+                  _searchController.text = keyword;
+                  _onSearchChanged(keyword);
+                  _focusNode.unfocus();
+                },
               );
             },
           ),
@@ -171,7 +176,7 @@ class _SearchScreenState extends State<SearchScreen> {
           ),
           const SizedBox(height: 32),
           const PopularCoursesSection(),
-          const SizedBox(height: 20),
+          const SizedBox(height: 32),
         ],
       ),
     );

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,3 +1,4 @@
+import 'package:plogo/features/search/services/search_api_service.dart';
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import '../widgets/search_text_field.dart';
@@ -5,7 +6,10 @@ import '../widgets/recent_searches.dart';
 import '../widgets/search_region_item.dart';
 import '../widgets/search_course_item.dart';
 import '../widgets/recent_viewed_courses_section.dart';
+import 'package:plogo/core/api/api_client.dart';
+import 'package:plogo/features/mypage/services/mypage_service.dart';
 import '../widgets/popular_courses_section.dart';
+import 'package:plogo/features/search/services/search_service.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -18,6 +22,11 @@ class _SearchScreenState extends State<SearchScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _focusNode = FocusNode();
 
+  Future<List<Map<String, dynamic>>>? _recentCoursesFuture;
+  Future<List<String>>? _recentKeywordsFuture;
+  Future<List<Map<String, dynamic>>>? _regionResultsFuture;
+  Future<List<Map<String, dynamic>>>? _courseResultsFuture;
+
   @override
   void initState() {
     super.initState();
@@ -25,6 +34,8 @@ class _SearchScreenState extends State<SearchScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
     });
+  _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
+  _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
   }
 
   @override
@@ -45,9 +56,8 @@ class _SearchScreenState extends State<SearchScreen> {
             SearchTextField(
               controller: _searchController,
               focusNode: _focusNode,
-              onChanged: () => setState(() {}),
+              onChanged: () => _onSearchChanged(_searchController.text),
             ),
-
             // 검색 결과 영역
             Expanded(
               child: _searchController.text.isEmpty
@@ -60,23 +70,74 @@ class _SearchScreenState extends State<SearchScreen> {
     );
   }
 
+  void _onSearchChanged(String value) {
+    final query = value.trim();
+    if (query.isEmpty) {
+      setState(() {
+        _regionResultsFuture = null;
+        _courseResultsFuture = null;
+      });
+      return;
+    }
+    final api = SearchApiService(apiClient.dio);
+    setState(() {
+      _regionResultsFuture = api.getSigunguList().then((regions) =>
+        regions.where((r) => r['sigunguName']?.toString().contains(query) ?? false).toList()
+      );
+      _courseResultsFuture = api.searchCourses(query);
+    });
+  }
+
   Widget _buildRecentSearches() {
-    // TODO: 실제 데이터 연동
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // 최근 검색어
-          RecentSearches(
-            keywords: const ['국립공원', '남양주 공원', '인천', '인천'],
-            onDelete: (keyword) {
-              // TODO: 최근 검색어 삭제 로직
+          FutureBuilder<List<String>>(
+            future: _recentKeywordsFuture,
+            builder: (context, snapshot) {
+              if (_recentKeywordsFuture == null || snapshot.connectionState == ConnectionState.waiting) {
+                return const SizedBox(height: 40, child: Center(child: CircularProgressIndicator()));
+              }
+              if (snapshot.hasError) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text('최근 검색어 불러오기 실패', style: TextStyle(color: Colors.red)),
+                );
+              }
+              final keywords = snapshot.data ?? [];
+              return RecentSearches(
+                keywords: keywords,
+                onDelete: (keyword) {
+                  // TODO: 최근 검색어 삭제 로직
+                },
+              );
             },
           ),
 
           const SizedBox(height: 32),
 
-          const RecentViewedCoursesSection(),
+          // 최근 확인한 코스
+          FutureBuilder<List<Map<String, dynamic>>>(
+            future: _recentCoursesFuture,
+            builder: (context, snapshot) {
+              if (_recentCoursesFuture == null || snapshot.connectionState == ConnectionState.waiting) {
+                return const SizedBox(
+                  height: 128,
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              if (snapshot.hasError) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text('최근 확인한 코스 불러오기 실패', style: TextStyle(color: Colors.red)),
+                );
+              }
+              final items = snapshot.data ?? [];
+              return RecentViewedCoursesSection(items: items);
+            },
+          ),
 
           const SizedBox(height: 32),
 
@@ -257,68 +318,60 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   Widget _buildSearchResults() {
-    final query = _searchController.text.toLowerCase();
-
-    // 샘플 데이터
-    final regions = [
-      {'name': '문경', 'fullName': '경상북도 문경시'},
-      {'name': '대전', 'fullName': '대전광역시'},
-      {'name': '세종', 'fullName': '세종특별자치시'},
-      {'name': '서울', 'fullName': '서울특별시'},
-    ];
-
-    final courses = [
-      {'name': '문경새재 도립공원', 'address': '경상북도 문경시 문경읍 새재로 932'},
-      {'name': '문경 용추계곡', 'address': '경상북도 문경시 가은읍 완장리'},
-      {'name': '세종호수공원', 'address': '세종특별자치시 연기면'},
-      {'name': '서울숲', 'address': '서울특별시 성동구 뚝섬로'},
-    ];
-
-    // 검색어로 필터링
-    final filteredRegions =
-        regions.where((r) => r['name']!.toLowerCase().contains(query)).toList();
-
-    final filteredCourses = courses
-        .where((c) =>
-            c['name']!.toLowerCase().contains(query) ||
-            c['address']!.toLowerCase().contains(query))
-        .toList();
-
-    // 결과가 없을 때
-    if (filteredRegions.isEmpty && filteredCourses.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(40),
-          child: Text(
-            '검색 결과가 없습니다',
-            style: TextStyle(
-              fontSize: 16,
-              color: AppColors.grey,
-            ),
-          ),
-        ),
-      );
-    }
-
     return ListView(
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.only(top: 0, left: 24, right: 24, bottom: 20),
       children: [
-        // 지역 결과
-        ...filteredRegions.map((region) => SearchRegionItem(
-              query: _searchController.text,
-              name: region['name']!,
-              fullName: region['fullName']!,
-            )),
-
-        if (filteredCourses.isNotEmpty) const SizedBox(height: 20),
-
-        // 코스 결과
-        ...filteredCourses.map((course) => SearchCourseItem(
-              query: _searchController.text,
-              name: course['name']!,
-              address: course['address']!,
-              iconPath: 'assets/images/sample.png',
-            )),
+        FutureBuilder<List<Map<String, dynamic>>>(
+          future: _regionResultsFuture,
+          builder: (context, snapshot) {
+            if (_regionResultsFuture == null) return const SizedBox();
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final regions = snapshot.data ?? [];
+            if (regions.isEmpty) return const SizedBox();
+            return Column(
+              children: regions.map((region) => SearchRegionItem(
+                query: _searchController.text,
+                name: region['sigunguName'] ?? '',
+                fullName: region['withArea'] ?? '',
+              )).toList(),
+            );
+          },
+        ),
+        const SizedBox(height: 20),
+        FutureBuilder<List<Map<String, dynamic>>>(
+          future: _courseResultsFuture,
+          builder: (context, snapshot) {
+            if (_courseResultsFuture == null) return const SizedBox();
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final courses = snapshot.data ?? [];
+            if (courses.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(40),
+                  child: Text(
+                    '검색 결과가 없습니다',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: AppColors.grey,
+                    ),
+                  ),
+                ),
+              );
+            }
+            return Column(
+              children: courses.map((course) => SearchCourseItem(
+                query: _searchController.text,
+                name: course['name'] ?? '',
+                address: course['area'] ?? '',
+                iconPath: course['image'] ?? 'assets/images/sample.png',
+              )).toList(),
+            );
+          },
+        ),
       ],
     );
   }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,4 +1,3 @@
-import 'package:plogo/features/search/services/search_api_service.dart';
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
@@ -7,13 +6,14 @@ import '../widgets/recent_searches.dart';
 import '../widgets/search_region_item.dart';
 import '../widgets/search_course_item.dart';
 import '../widgets/recent_viewed_courses_section.dart';
+import '../widgets/popular_courses_section.dart';
 import 'package:plogo/core/api/api_client.dart';
 import 'package:plogo/features/mypage/services/mypage_service.dart';
-import '../widgets/popular_courses_section.dart';
 import 'package:plogo/features/search/services/search_service.dart';
+import 'package:plogo/features/search/services/search_api_service.dart';
 
 class SearchScreen extends StatefulWidget {
-  const SearchScreen({super.key});
+  const SearchScreen({Key? key}) : super(key: key);
 
   @override
   State<SearchScreen> createState() => _SearchScreenState();
@@ -26,66 +26,39 @@ class _SearchScreenState extends State<SearchScreen> {
 
   Future<List<Map<String, dynamic>>>? _recentCoursesFuture;
   Future<List<String>>? _recentKeywordsFuture;
-  // 최근 검색어 삭제 함수
-  Future<void> _deleteKeyword(String keyword) async {
-    final service = SearchService(apiClient.dio);
-    final success = await service.deleteKeyword(keyword);
-    if (success) {
-      setState(() {
-        // 삭제 후 최근 검색어 목록 새로고침
-        _recentKeywordsFuture = service.getRecentKeywords();
-      });
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('검색어 삭제에 실패했습니다')),
-      );
-    }
-  }
   Future<List<Map<String, dynamic>>>? _regionResultsFuture;
   Future<List<Map<String, dynamic>>>? _courseResultsFuture;
 
   @override
   void initState() {
     super.initState();
-    // 화면 진입 시 자동으로 키보드 포커스
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
     });
-  _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
-  _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
+    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
+    _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
   }
 
   @override
   void dispose() {
-  _debounceTimer?.cancel();
+    _debounceTimer?.cancel();
     _searchController.dispose();
     _focusNode.dispose();
     super.dispose();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.white,
-      body: SafeArea(
-        child: Column(
-          children: [
-            // 상단 검색바
-            SearchTextField(
-              controller: _searchController,
-              focusNode: _focusNode,
-              onChanged: () => _onSearchChanged(_searchController.text),
-            ),
-            // 검색 결과 영역
-            Expanded(
-              child: _searchController.text.isEmpty
-                  ? _buildRecentSearches()
-                  : _buildSearchResults(),
-            ),
-          ],
-        ),
-      ),
-    );
+  Future<void> _deleteKeyword(String keyword) async {
+    final service = SearchService(apiClient.dio);
+    final success = await service.deleteKeyword(keyword);
+    if (success) {
+      setState(() {
+        _recentKeywordsFuture = service.getRecentKeywords();
+      });
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('검색어 삭제에 실패했습니다')),
+      );
+    }
   }
 
   void _onSearchChanged(String value) {
@@ -96,6 +69,7 @@ class _SearchScreenState extends State<SearchScreen> {
         setState(() {
           _regionResultsFuture = null;
           _courseResultsFuture = null;
+          _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
         });
         return;
       }
@@ -109,12 +83,53 @@ class _SearchScreenState extends State<SearchScreen> {
     });
   }
 
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        print('뒤로가기 호출됨, 검색어: \'${_searchController.text}\'');
+        if (_searchController.text.isNotEmpty) {
+          setState(() {
+            _searchController.clear();
+            _regionResultsFuture = null;
+            _courseResultsFuture = null;
+            _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
+          });
+          Future.delayed(const Duration(milliseconds: 100), () {
+            _focusNode.requestFocus();
+          });
+          return false;
+        }
+        print('pop 허용');
+        return true;
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.white,
+        body: SafeArea(
+          child: Column(
+            children: [
+              SearchTextField(
+                controller: _searchController,
+                focusNode: _focusNode,
+                onChanged: () => _onSearchChanged(_searchController.text),
+              ),
+              Expanded(
+                child: _searchController.text.isEmpty
+                    ? _buildRecentSearches()
+                    : _buildSearchResults(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildRecentSearches() {
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 최근 검색어
           FutureBuilder<List<String>>(
             future: _recentKeywordsFuture,
             builder: (context, snapshot) {
@@ -122,8 +137,8 @@ class _SearchScreenState extends State<SearchScreen> {
                 return const SizedBox(height: 40, child: Center(child: CircularProgressIndicator()));
               }
               if (snapshot.hasError) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                return const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
                   child: Text('최근 검색어 불러오기 실패', style: TextStyle(color: Colors.red)),
                 );
               }
@@ -134,10 +149,7 @@ class _SearchScreenState extends State<SearchScreen> {
               );
             },
           ),
-
           const SizedBox(height: 32),
-
-          // 최근 확인한 코스
           FutureBuilder<List<Map<String, dynamic>>>(
             future: _recentCoursesFuture,
             builder: (context, snapshot) {
@@ -148,197 +160,26 @@ class _SearchScreenState extends State<SearchScreen> {
                 );
               }
               if (snapshot.hasError) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                return const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
                   child: Text('최근 확인한 코스 불러오기 실패', style: TextStyle(color: Colors.red)),
                 );
               }
-              final items = snapshot.data ?? [];
+              final items = snapshot.data ?? <Map<String, dynamic>>[];
               return RecentViewedCoursesSection(items: items);
             },
           ),
-
           const SizedBox(height: 32),
-
           const PopularCoursesSection(),
-
           const SizedBox(height: 32),
         ],
       ),
     );
-  }
-
-  Widget _buildCourseCard(String name, String location, String imagePath) {
-    return Container(
-      width: 160,
-      height: 160,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        color: AppColors.greyLight,
-      ),
-      clipBehavior: Clip.hardEdge,
-      child: Stack(
-        children: [
-          // 배경 이미지
-          Positioned.fill(
-            child: Image.asset(
-              imagePath,
-              fit: BoxFit.cover,
-              errorBuilder: (context, error, stackTrace) => Container(
-                color: AppColors.border,
-                child: const Icon(
-                  Icons.image,
-                  size: 40,
-                  color: AppColors.grey,
-                ),
-              ),
-            ),
-          ),
-          // 하단 그라데이션
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    Colors.black.withOpacity(0.7),
-                  ],
-                ),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    name,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    location,
-                    style: TextStyle(
-                      color: Colors.white.withOpacity(0.8),
-                      fontSize: 12,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          // 북마크 아이콘
-          const Positioned(
-            top: 8,
-            right: 8,
-            child: Icon(
-              Icons.bookmark_border,
-              color: Colors.white,
-              size: 24,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildPopularCourseItem(int rank, String name, int? rightRank) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: Row(
-        children: [
-          // 왼쪽 랭킹 + 이름
-          Expanded(
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 20,
-                  child: Text(
-                    '$rank',
-                    style: const TextStyle(
-                      color: AppColors.primary,
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Text(
-                    name,
-                    style: const TextStyle(
-                      fontSize: 15,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          // 오른쪽 랭킹 + 이름 (있는 경우)
-          if (rightRank != null) ...[
-            const SizedBox(width: 24),
-            Expanded(
-              child: Row(
-                children: [
-                  SizedBox(
-                    width: 20,
-                    child: Text(
-                      '$rightRank',
-                      style: const TextStyle(
-                        color: AppColors.primary,
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Text(
-                      _getPopularCourseName(rightRank),
-                      style: const TextStyle(
-                        fontSize: 15,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  String _getPopularCourseName(int rank) {
-    const names = {
-      6: '안양천 생태아이가든',
-      7: '한려해상 국립공원',
-      8: '경안천 습지생태공원',
-      9: '목포시 특장자생식물원',
-      10: '낙동강 하구명소',
-    };
-    return names[rank] ?? '';
   }
 
   Widget _buildSearchResults() {
     return ListView(
-      padding: const EdgeInsets.only(top: 0, left: 24, right: 24, bottom: 20),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       children: [
         FutureBuilder<List<Map<String, dynamic>>>(
           future: _regionResultsFuture,
@@ -373,7 +214,7 @@ class _SearchScreenState extends State<SearchScreen> {
                   padding: const EdgeInsets.all(40),
                   child: Text(
                     '검색 결과가 없습니다',
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontSize: 16,
                       color: AppColors.grey,
                     ),

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -171,7 +171,7 @@ class _SearchScreenState extends State<SearchScreen> {
           ),
           const SizedBox(height: 32),
           const PopularCoursesSection(),
-          const SizedBox(height: 32),
+          const SizedBox(height: 20),
         ],
       ),
     );
@@ -179,7 +179,7 @@ class _SearchScreenState extends State<SearchScreen> {
 
   Widget _buildSearchResults() {
     return ListView(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.only(top: 0, bottom: 12, left: 12, right: 12),
       children: [
         FutureBuilder<List<Map<String, dynamic>>>(
           future: _regionResultsFuture,

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,17 +1,14 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import '../widgets/search_text_field.dart';
-import '../widgets/recent_searches.dart';
-import '../widgets/search_region_item.dart';
-import '../widgets/search_course_item.dart';
-import '../widgets/recent_viewed_courses_section.dart';
-import '../widgets/popular_courses_section.dart';
-import 'package:plogo/core/api/api_client.dart';
-import 'package:plogo/features/mypage/services/mypage_service.dart';
+import '../widgets/search_recent_section.dart';
+import '../widgets/search_results_section.dart';
+import 'package:plogo/features/search/providers/search_provider.dart';
 import 'package:plogo/features/search/services/search_service.dart';
-import 'package:plogo/features/search/services/search_api_service.dart';
-import 'package:go_router/go_router.dart';
+import 'package:plogo/core/api/api_client.dart';
+
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({Key? key}) : super(key: key);
@@ -21,30 +18,18 @@ class SearchScreen extends StatefulWidget {
 }
 
 class _SearchScreenState extends State<SearchScreen> {
+  late final TextEditingController _searchController;
+  late final FocusNode _focusNode;
   Timer? _debounceTimer;
-  final TextEditingController _searchController = TextEditingController();
-  final FocusNode _focusNode = FocusNode();
-
-  Future<List<Map<String, dynamic>>>? _recentCoursesFuture;
-  Future<List<String>>? _recentKeywordsFuture;
-  Future<List<Map<String, dynamic>>>? _regionResultsFuture;
-  Future<List<Map<String, dynamic>>>? _courseResultsFuture;
 
   @override
   void initState() {
     super.initState();
+    _searchController = TextEditingController();
+    _focusNode = FocusNode();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusNode.requestFocus();
     });
-    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
-    _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // 검색화면이 다시 보일 때마다 최근 코스 Future 갱신
-    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
   }
 
   @override
@@ -55,211 +40,73 @@ class _SearchScreenState extends State<SearchScreen> {
     super.dispose();
   }
 
-  Future<void> _deleteKeyword(String keyword) async {
-    final service = SearchService(apiClient.dio);
-    final success = await service.deleteKeyword(keyword);
-    if (success) {
-      setState(() {
-        _recentKeywordsFuture = service.getRecentKeywords();
-      });
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('검색어 삭제에 실패했습니다')),
-      );
-    }
-  }
-
-  void _onSearchChanged(String value) {
+  void _onSearchChanged(WidgetRef ref) {
     _debounceTimer?.cancel();
     _debounceTimer = Timer(const Duration(milliseconds: 400), () {
-      final query = value.trim();
-      if (query.isEmpty) {
-        setState(() {
-          _regionResultsFuture = null;
-          _courseResultsFuture = null;
-          _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
-        });
-        return;
+      final keyword = _searchController.text.trim();
+      print('[디바운스 후 검색어] $keyword');
+      ref.read(searchQueryProvider.notifier).state = keyword;
+      if (keyword.isEmpty) {
+        _focusNode.requestFocus();
+      } else {
+        ref.refresh(recentKeywordsProvider); // 검색 시 최근 검색어 강제 갱신
+        ref.refresh(regionResultsProvider(keyword)); // 검색 시 시군구 리스트 강제 갱신
+        ref.refresh(courseResultsProvider(keyword)); // 검색 시 코스 조회 강제 갱신
       }
-      final api = SearchApiService(apiClient.dio);
-      setState(() {
-        _regionResultsFuture = api.getSigunguList().then((regions) =>
-          regions.where((r) => r['sigunguName']?.toString().contains(query) ?? false).toList()
-        );
-        _courseResultsFuture = api.searchCourses(query);
-      });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        print('뒤로가기 호출됨, 검색어: \'${_searchController.text}\'');
-        if (_searchController.text.isNotEmpty) {
-          setState(() {
-            _searchController.clear();
-            _regionResultsFuture = null;
-            _courseResultsFuture = null;
-            _recentKeywordsFuture = SearchService(apiClient.dio).getRecentKeywords();
-          });
-          Future.delayed(const Duration(milliseconds: 100), () {
-            _focusNode.requestFocus();
-          });
-          return false;
-        }
-        print('pop 허용');
-        return true;
-      },
-      child: Scaffold(
-        backgroundColor: AppColors.white,
-        body: SafeArea(
-          child: Column(
-            children: [
-              SearchTextField(
-                controller: _searchController,
-                focusNode: _focusNode,
-                onChanged: () => _onSearchChanged(_searchController.text),
-              ),
-              Expanded(
-                child: _searchController.text.isEmpty
-                    ? _buildRecentSearches()
-                    : _buildSearchResults(),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildRecentSearches() {
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          FutureBuilder<List<String>>(
-            future: _recentKeywordsFuture,
-            builder: (context, snapshot) {
-              if (_recentKeywordsFuture == null || snapshot.connectionState == ConnectionState.waiting) {
-                return const SizedBox(height: 40, child: Center(child: CircularProgressIndicator()));
-              }
-              if (snapshot.hasError) {
-                return const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24),
-                  child: Text('최근 검색어 불러오기 실패', style: TextStyle(color: Colors.red)),
-                );
-              }
-              final keywords = snapshot.data ?? [];
-              return RecentSearches(
-                keywords: keywords,
-                onDelete: _deleteKeyword,
-                onTap: (keyword) {
-                  _searchController.text = keyword;
-                  _onSearchChanged(keyword);
-                  _focusNode.unfocus();
-                },
-              );
-            },
-          ),
-          const SizedBox(height: 32),
-          FutureBuilder<List<Map<String, dynamic>>>(
-            future: _recentCoursesFuture,
-            builder: (context, snapshot) {
-              if (_recentCoursesFuture == null || snapshot.connectionState == ConnectionState.waiting) {
-                return const SizedBox(
-                  height: 128,
-                  child: Center(child: CircularProgressIndicator()),
-                );
-              }
-              if (snapshot.hasError) {
-                return const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24),
-                  child: Text('최근 확인한 코스 불러오기 실패', style: TextStyle(color: Colors.red)),
-                );
-              }
-              final items = snapshot.data ?? <Map<String, dynamic>>[];
-              return RecentViewedCoursesSection(
-                items: items,
-                onCardTap: (courseId, name) async {
-                  await context.push('/home/detail/$courseId', extra: name);
-                  setState(() {
-                    _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
-                  });
-                },
-              );
-            },
-          ),
-          const SizedBox(height: 32),
-          PopularCoursesSection(
-            onRefreshRecentCourses: () {
-              setState(() {
-                _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
+    return Consumer(
+      builder: (context, ref, _) {
+        final query = ref.watch(searchQueryProvider);
+        return WillPopScope(
+          onWillPop: () async {
+            if (_searchController.text.isNotEmpty) {
+              _searchController.clear();
+              ref.read(searchQueryProvider.notifier).state = '';
+              ref.refresh(recentKeywordsProvider);
+              Future.delayed(const Duration(milliseconds: 100), () {
+                _focusNode.requestFocus();
               });
-            },
-          ),
-          const SizedBox(height: 32),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSearchResults() {
-    return ListView(
-      padding: const EdgeInsets.only(top: 0, bottom: 12, left: 12, right: 12),
-      children: [
-        FutureBuilder<List<Map<String, dynamic>>>(
-          future: _regionResultsFuture,
-          builder: (context, snapshot) {
-            if (_regionResultsFuture == null) return const SizedBox();
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
+              return false;
             }
-            final regions = snapshot.data ?? [];
-            if (regions.isEmpty) return const SizedBox();
-            return Column(
-              children: regions.map((region) => SearchRegionItem(
-                query: _searchController.text,
-                name: region['sigunguName'] ?? '',
-                fullName: region['withArea'] ?? '',
-              )).toList(),
-            );
+            return true;
           },
-        ),
-        const SizedBox(height: 20),
-        FutureBuilder<List<Map<String, dynamic>>>(
-          future: _courseResultsFuture,
-          builder: (context, snapshot) {
-            if (_courseResultsFuture == null) return const SizedBox();
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            final courses = snapshot.data ?? [];
-            if (courses.isEmpty) {
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(40),
-                  child: Text(
-                    '검색 결과가 없습니다',
-                    style: const TextStyle(
-                      fontSize: 16,
-                      color: AppColors.grey,
-                    ),
+          child: Scaffold(
+            backgroundColor: AppColors.white,
+            body: SafeArea(
+              child: Column(
+                children: [
+                  SearchTextField(
+                    controller: _searchController,
+                    focusNode: _focusNode,
+                    onChanged: () => _onSearchChanged(ref),
                   ),
-                ),
-              );
-            }
-            return Column(
-              children: courses.map((course) => SearchCourseItem(
-                query: _searchController.text,
-                name: course['name'] ?? '',
-                address: course['area'] ?? '',
-                iconPath: course['image'] ?? 'assets/images/sample.png',
-              )).toList(),
-            );
-          },
-        ),
-      ],
+                  Expanded(
+                    child: _searchController.text.isEmpty
+                        ? SearchRecentSection(
+                            key: ValueKey(DateTime.now().millisecondsSinceEpoch),
+                            focusNode: _focusNode,
+                            searchController: _searchController,
+                          )
+                        : Builder(
+                            builder: (context) {
+                              WidgetsBinding.instance.addPostFrameCallback((_) {
+                                final ref = ProviderScope.containerOf(context, listen: false);
+                                ref.refresh(recentKeywordsProvider);
+                              });
+                              return SearchResultsSection(query: _searchController.text);
+                            },
+                          ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -191,7 +191,13 @@ class _SearchScreenState extends State<SearchScreen> {
             },
           ),
           const SizedBox(height: 32),
-          const PopularCoursesSection(),
+          PopularCoursesSection(
+            onRefreshRecentCourses: () {
+              setState(() {
+                _recentCoursesFuture = MyPageService(apiClient.dio).getRecentCourses();
+              });
+            },
+          ),
           const SizedBox(height: 32),
         ],
       ),

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,4 +1,5 @@
 import 'package:plogo/features/search/services/search_api_service.dart';
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import '../widgets/search_text_field.dart';
@@ -19,11 +20,27 @@ class SearchScreen extends StatefulWidget {
 }
 
 class _SearchScreenState extends State<SearchScreen> {
+  Timer? _debounceTimer;
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _focusNode = FocusNode();
 
   Future<List<Map<String, dynamic>>>? _recentCoursesFuture;
   Future<List<String>>? _recentKeywordsFuture;
+  // 최근 검색어 삭제 함수
+  Future<void> _deleteKeyword(String keyword) async {
+    final service = SearchService(apiClient.dio);
+    final success = await service.deleteKeyword(keyword);
+    if (success) {
+      setState(() {
+        // 삭제 후 최근 검색어 목록 새로고침
+        _recentKeywordsFuture = service.getRecentKeywords();
+      });
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('검색어 삭제에 실패했습니다')),
+      );
+    }
+  }
   Future<List<Map<String, dynamic>>>? _regionResultsFuture;
   Future<List<Map<String, dynamic>>>? _courseResultsFuture;
 
@@ -40,6 +57,7 @@ class _SearchScreenState extends State<SearchScreen> {
 
   @override
   void dispose() {
+  _debounceTimer?.cancel();
     _searchController.dispose();
     _focusNode.dispose();
     super.dispose();
@@ -71,20 +89,23 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   void _onSearchChanged(String value) {
-    final query = value.trim();
-    if (query.isEmpty) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 400), () {
+      final query = value.trim();
+      if (query.isEmpty) {
+        setState(() {
+          _regionResultsFuture = null;
+          _courseResultsFuture = null;
+        });
+        return;
+      }
+      final api = SearchApiService(apiClient.dio);
       setState(() {
-        _regionResultsFuture = null;
-        _courseResultsFuture = null;
+        _regionResultsFuture = api.getSigunguList().then((regions) =>
+          regions.where((r) => r['sigunguName']?.toString().contains(query) ?? false).toList()
+        );
+        _courseResultsFuture = api.searchCourses(query);
       });
-      return;
-    }
-    final api = SearchApiService(apiClient.dio);
-    setState(() {
-      _regionResultsFuture = api.getSigunguList().then((regions) =>
-        regions.where((r) => r['sigunguName']?.toString().contains(query) ?? false).toList()
-      );
-      _courseResultsFuture = api.searchCourses(query);
     });
   }
 
@@ -109,9 +130,7 @@ class _SearchScreenState extends State<SearchScreen> {
               final keywords = snapshot.data ?? [];
               return RecentSearches(
                 keywords: keywords,
-                onDelete: (keyword) {
-                  // TODO: 최근 검색어 삭제 로직
-                },
+                onDelete: _deleteKeyword,
               );
             },
           ),

--- a/lib/features/search/services/search_api_service.dart
+++ b/lib/features/search/services/search_api_service.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+
+class SearchApiService {
+  final Dio _dio;
+  SearchApiService(this._dio);
+
+///코스 검색
+  Future<List<Map<String, dynamic>>> searchCourses(String keyword) async {
+    final response = await _dio.get('/search/course/$keyword');
+    print('[searchCourses] keyword: $keyword, response: ${response.data}');
+    if (response.data != null && response.data['isSuccess'] == true) {
+      final data = response.data['data'] as List<dynamic>?;
+      if (data != null) {
+        return List<Map<String, dynamic>>.from(data);
+      }
+    }
+    return [];
+  }
+
+///시군구 코드 불러오기
+  Future<List<Map<String, dynamic>>> getSigunguList() async {
+    final response = await _dio.get('/search/sigungu_code');
+    print('[getSigunguList] response: ${response.data}');
+    if (response.data != null && response.data['isSuccess'] == true) {
+      final data = response.data['data'] as List<dynamic>?;
+      if (data != null) {
+        return List<Map<String, dynamic>>.from(data);
+      }
+    }
+    return [];
+  }
+}

--- a/lib/features/search/services/search_service.dart
+++ b/lib/features/search/services/search_service.dart
@@ -15,4 +15,19 @@ class SearchService {
     }
     return [];
   }
+
+  /// 최근 검색어 삭제
+  Future<bool> deleteKeyword(String keyword) async {
+    try {
+  print('[deleteKeyword] PATCH /search/delete/$keyword');
+  final response = await _dio.patch('/search/delete/$keyword');
+      print('[deleteKeyword] response: ${response.data}');
+      if (response.data != null && response.data['isSuccess'] == true) {
+        return true;
+      }
+    } catch (e) {
+      print('검색어 삭제 실패: $e');
+    }
+    return false;
+  }
 }

--- a/lib/features/search/services/search_service.dart
+++ b/lib/features/search/services/search_service.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+
+class SearchService {
+  final Dio _dio;
+  SearchService(this._dio);
+
+/// 최근 검색어 불러오기
+  Future<List<String>> getRecentKeywords() async {
+    final response = await _dio.get('/search/recent');
+    if (response.data != null && response.data['isSuccess'] == true) {
+      final data = response.data['data'] as List<dynamic>?;
+      if (data != null) {
+        return data.map((e) => e['keyword'] as String).toList();
+      }
+    }
+    return [];
+  }
+}

--- a/lib/features/search/widgets/popular_courses_section.dart
+++ b/lib/features/search/widgets/popular_courses_section.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
-
-
 import 'package:plogo/features/home/services/hot_course_service.dart';
 import 'package:plogo/features/home/models/course_models.dart';
+import 'package:go_router/go_router.dart';
 
 class PopularCoursesSection extends StatefulWidget {
-  const PopularCoursesSection({super.key});
+  final VoidCallback? onRefreshRecentCourses;
+
+  const PopularCoursesSection({super.key, this.onRefreshRecentCourses});
 
   @override
   State<PopularCoursesSection> createState() => _PopularCoursesSectionState();
@@ -85,29 +86,37 @@ class _PopularCoursesSectionState extends State<PopularCoursesSection> {
   Widget _courseItem(CourseRecommendItem course, int rank) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 32),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 20,
-            child: Text(
-              '$rank',
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
+      child: InkWell(
+        onTap: () async {
+          await context.push('/home/detail/${course.courseId}', extra: course.name);
+          if (widget.onRefreshRecentCourses != null) {
+            widget.onRefreshRecentCourses!();
+          }
+        },
+        child: Row(
+          children: [
+            SizedBox(
+              width: 20,
+              child: Text(
+                '$rank',
+                style: const TextStyle(
+                  color: AppColors.primary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Text(
-              course.name,
-              style: const TextStyle(fontSize: 15),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                course.name,
+                style: const TextStyle(fontSize: 15),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/search/widgets/popular_courses_section.dart
+++ b/lib/features/search/widgets/popular_courses_section.dart
@@ -1,90 +1,110 @@
 import 'package:flutter/material.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 
-class PopularCoursesSection extends StatelessWidget {
+
+import 'package:plogo/features/home/services/hot_course_service.dart';
+import 'package:plogo/features/home/models/course_models.dart';
+
+class PopularCoursesSection extends StatefulWidget {
   const PopularCoursesSection({super.key});
+
+  @override
+  State<PopularCoursesSection> createState() => _PopularCoursesSectionState();
+}
+
+class _PopularCoursesSectionState extends State<PopularCoursesSection> {
+  late Future<CourseRecommendResponse> _hotCoursesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _hotCoursesFuture = HotCourseService().getHotCourses();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            '인기 코스',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 16),
-          _row(1, '주왕산 국립공원', 6, '안양천 생태아이가든'),
-          _row(2, '백룡동굴', 7, '한려해상 국립공원'),
-          _row(3, '동림저수지', 8, '경안천 습지생태공원'),
-          _row(4, '북한산 생태탐방연수원', 9, '목포시 특장자생식물원'),
-          _row(5, '무주반디랜드 반딧불이...', 10, '낙동강 하구명소'),
-        ],
+      child: FutureBuilder<CourseRecommendResponse>(
+        future: _hotCoursesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Text('인기 코스 불러오기 실패', style: TextStyle(color: Colors.red));
+          }
+          final courses = snapshot.data?.data ?? [];
+          if (courses.isEmpty) {
+            return const Text('인기 코스가 없습니다');
+          }
+          final half = (courses.length / 2).ceil();
+          final leftList = courses.take(half).toList();
+          final rightList = courses.skip(half).toList();
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '인기 코스',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      children: List.generate(leftList.length, (i) {
+                        final course = leftList[i];
+                        return _courseItem(course, i + 1);
+                      }),
+                    ),
+                  ),
+                  const SizedBox(width: 24),
+                  Expanded(
+                    child: Column(
+                      children: List.generate(rightList.length, (i) {
+                        final course = rightList[i];
+                        return _courseItem(course, half + i + 1);
+                      }),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          );
+        },
       ),
     );
   }
 
-  Widget _row(int leftRank, String leftName, int rightRank, String rightName) {
+  Widget _courseItem(CourseRecommendItem course, int rank) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.only(bottom: 32),
       child: Row(
         children: [
-          Expanded(
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 20,
-                  child: Text(
-                    '$leftRank',
-                    style: const TextStyle(
-                      color: AppColors.primary,
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Text(
-                    leftName,
-                    style: const TextStyle(fontSize: 15),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
+          SizedBox(
+            width: 20,
+            child: Text(
+              '$rank',
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
-          const SizedBox(width: 24),
+          const SizedBox(width: 16),
           Expanded(
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 20,
-                  child: Text(
-                    '$rightRank',
-                    style: const TextStyle(
-                      color: AppColors.primary,
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Text(
-                    rightName,
-                    style: const TextStyle(fontSize: 15),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
+            child: Text(
+              course.name,
+              style: const TextStyle(fontSize: 15),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
         ],

--- a/lib/features/search/widgets/recent_searches.dart
+++ b/lib/features/search/widgets/recent_searches.dart
@@ -4,11 +4,13 @@ import 'package:plogo/shared/theme/app_colors.dart';
 class RecentSearches extends StatelessWidget {
   final List<String> keywords;
   final Function(String) onDelete;
+  final Function(String)? onTap;
 
   const RecentSearches({
     super.key,
     required this.keywords,
     required this.onDelete,
+    this.onTap,
   });
 
   @override
@@ -36,27 +38,30 @@ class RecentSearches extends StatelessWidget {
             separatorBuilder: (_, __) => const SizedBox(width: 8),
             itemBuilder: (context, index) {
               final keyword = keywords[index];
-              return Chip(
-                label: Text(
-                  keyword,
-                  style: const TextStyle(
-                    color: AppColors.black,
-                    fontSize: 14,
+              return GestureDetector(
+                onTap: () => onTap?.call(keyword),
+                child: Chip(
+                  label: Text(
+                    keyword,
+                    style: const TextStyle(
+                      color: AppColors.black,
+                      fontSize: 14,
+                    ),
                   ),
+                  deleteIcon: const Icon(
+                    Icons.close,
+                    size: 16,
+                    color: AppColors.grey,
+                  ),
+                  onDeleted: () => onDelete(keyword),
+                  backgroundColor: AppColors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: const BorderSide(color: AppColors.greyLight),
+                  ),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: const VisualDensity(horizontal: 0, vertical: 0),
                 ),
-                deleteIcon: const Icon(
-                  Icons.close,
-                  size: 16,
-                  color: AppColors.grey,
-                ),
-                onDeleted: () => onDelete(keyword),
-                backgroundColor: AppColors.white,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                  side: const BorderSide(color: AppColors.greyLight),
-                ),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                visualDensity: const VisualDensity(horizontal: 0, vertical: 0),
               );
             },
           ),

--- a/lib/features/search/widgets/recent_searches.dart
+++ b/lib/features/search/widgets/recent_searches.dart
@@ -30,7 +30,7 @@ class RecentSearches extends StatelessWidget {
         SizedBox(
           height: 44,
           child: ListView.separated(
-            padding: const EdgeInsets.only(left: 24),
+            padding: const EdgeInsets.only(left: 24, right: 24),
             scrollDirection: Axis.horizontal,
             itemCount: keywords.length,
             separatorBuilder: (_, __) => const SizedBox(width: 8),

--- a/lib/features/search/widgets/recent_searches.dart
+++ b/lib/features/search/widgets/recent_searches.dart
@@ -30,7 +30,7 @@ class RecentSearches extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         SizedBox(
-          height: 44,
+          height: 36,
           child: ListView.separated(
             padding: const EdgeInsets.only(left: 24, right: 24),
             scrollDirection: Axis.horizontal,

--- a/lib/features/search/widgets/search_course_item.dart
+++ b/lib/features/search/widgets/search_course_item.dart
@@ -83,17 +83,29 @@ class SearchCourseItem extends StatelessWidget {
                 width: 60,
                 height: 60,
                 color: AppColors.greyLight,
-                child: Image.asset(
-                  iconPath,
-                  width: 60,
-                  height: 60,
-                  fit: BoxFit.cover,
-                  errorBuilder: (context, error, stackTrace) => const Icon(
-                    Icons.image,
-                    color: AppColors.grey,
-                    size: 30,
-                  ),
-                ),
+                child: iconPath.startsWith('http')
+                    ? Image.network(
+                        iconPath,
+                        width: 60,
+                        height: 60,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) => const Icon(
+                          Icons.image,
+                          color: AppColors.grey,
+                          size: 30,
+                        ),
+                      )
+                    : Image.asset(
+                        iconPath,
+                        width: 60,
+                        height: 60,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) => const Icon(
+                          Icons.image,
+                          color: AppColors.grey,
+                          size: 30,
+                        ),
+                      ),
               ),
             ),
             const SizedBox(width: 12),

--- a/lib/features/search/widgets/search_recent_section.dart
+++ b/lib/features/search/widgets/search_recent_section.dart
@@ -53,6 +53,8 @@ class _SearchRecentSectionState extends State<SearchRecentSection> {
                   widget.focusNode!.unfocus();
                   ref.read(searchQueryProvider.notifier).state = keyword;
                   ref.refresh(recentKeywordsProvider); // 클릭 시 최근검색어 즉시 갱신
+                  ref.refresh(regionResultsProvider(keyword)); // 클릭 시 시군구 리스트 강제 갱신
+                  ref.refresh(courseResultsProvider(keyword)); // 클릭 시 코스 조회 강제 갱신
                 }
               },
             ),

--- a/lib/features/search/widgets/search_recent_section.dart
+++ b/lib/features/search/widgets/search_recent_section.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:plogo/features/search/providers/search_provider.dart';
+import 'package:plogo/features/search/services/search_service.dart';
+import 'package:plogo/core/api/api_client.dart';
+import 'package:plogo/shared/theme/app_colors.dart';
+import 'package:go_router/go_router.dart';
+import '../widgets/recent_searches.dart';
+import '../widgets/recent_viewed_courses_section.dart';
+import '../widgets/popular_courses_section.dart';
+
+class SearchRecentSection extends StatefulWidget {
+  final FocusNode? focusNode;
+  final TextEditingController? searchController;
+  const SearchRecentSection({this.focusNode, this.searchController, super.key});
+
+  @override
+  State<SearchRecentSection> createState() => _SearchRecentSectionState();
+}
+
+class _SearchRecentSectionState extends State<SearchRecentSection> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final recentKeywords = ref.watch(recentKeywordsProvider);
+        recentKeywords.when(
+          data: (keywords) => print('[최근검색어 리스트] $keywords'),
+          loading: () {},
+          error: (_, __) {},
+        );
+        final recentCourses = ref.watch(recentCoursesProvider);
+        return SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+          recentKeywords.when(
+            data: (keywords) => RecentSearches(
+              keywords: keywords,
+              onDelete: (keyword) async {
+                final success = await SearchService(apiClient.dio).deleteKeyword(keyword);
+                if (success) {
+                  ref.refresh(recentKeywordsProvider);
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('검색어 삭제에 실패했습니다')),
+                  );
+                }
+              },
+              onTap: (keyword) {
+                if (widget.searchController != null && widget.focusNode != null) {
+                  widget.searchController!.text = keyword;
+                  widget.focusNode!.unfocus();
+                  ref.read(searchQueryProvider.notifier).state = keyword;
+                  ref.refresh(recentKeywordsProvider); // 클릭 시 최근검색어 즉시 갱신
+                }
+              },
+            ),
+            loading: () => const SizedBox(height: 40, child: Center(child: CircularProgressIndicator())),
+            error: (_, __) => const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 24),
+              child: Text('최근 검색어 불러오기 실패', style: TextStyle(color: Colors.red)),
+            ),
+          ),
+          const SizedBox(height: 32),
+          recentCourses.when(
+            data: (items) => RecentViewedCoursesSection(
+              items: items,
+              onCardTap: (courseId, name) async {
+                if (context.mounted) {
+                  await context.push('/home/detail/$courseId', extra: name);
+                  ref.refresh(recentCoursesProvider);
+                }
+              },
+            ),
+            loading: () => const SizedBox(height: 128, child: Center(child: CircularProgressIndicator())),
+            error: (_, __) => const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 24),
+              child: Text('최근 확인한 코스 불러오기 실패', style: TextStyle(color: Colors.red)),
+            ),
+          ),
+          const SizedBox(height: 32),
+          PopularCoursesSection(
+            onRefreshRecentCourses: () {
+              ref.refresh(recentCoursesProvider);
+            },
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+      },
+    );
+  }
+}

--- a/lib/features/search/widgets/search_recent_section.dart
+++ b/lib/features/search/widgets/search_recent_section.dart
@@ -20,6 +20,12 @@ class SearchRecentSection extends StatefulWidget {
 
 class _SearchRecentSectionState extends State<SearchRecentSection> {
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final ref = ProviderScope.containerOf(context, listen: false);
+    ref.refresh(recentCoursesProvider);
+  }
+  @override
   Widget build(BuildContext context) {
     return Consumer(
       builder: (context, ref, _) {

--- a/lib/features/search/widgets/search_region_item.dart
+++ b/lib/features/search/widgets/search_region_item.dart
@@ -42,7 +42,7 @@ class SearchRegionItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       child: Row(
         children: [
           ColorFiltered(

--- a/lib/features/search/widgets/search_results_section.dart
+++ b/lib/features/search/widgets/search_results_section.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:plogo/features/search/providers/search_provider.dart';
+import 'package:plogo/shared/theme/app_colors.dart';
+import '../widgets/search_region_item.dart';
+import '../widgets/search_course_item.dart';
+
+class SearchResultsSection extends ConsumerWidget {
+  final String query;
+  const SearchResultsSection({required this.query, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final regionResults = ref.watch(regionResultsProvider(query));
+    final courseResults = ref.watch(courseResultsProvider(query));
+    return ListView(
+      padding: const EdgeInsets.only(top: 0, bottom: 12, left: 12, right: 12),
+      children: [
+        regionResults.when(
+          data: (regions) => regions.isEmpty
+              ? const SizedBox()
+              : Column(
+                  children: regions.map((region) => SearchRegionItem(
+                    query: query,
+                    name: region['sigunguName'] ?? '',
+                    fullName: region['withArea'] ?? '',
+                  )).toList(),
+                ),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, __) => const SizedBox(),
+        ),
+        const SizedBox(height: 20),
+        courseResults.when(
+          data: (courses) => courses.isEmpty
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(40),
+                    child: Text(
+                      '검색 결과가 없습니다',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        color: AppColors.grey,
+                      ),
+                    ),
+                  ),
+                )
+              : Column(
+                  children: courses.map((course) => SearchCourseItem(
+                    query: query,
+                    name: course['name'] ?? '',
+                    address: course['area'] ?? '',
+                    iconPath: course['image'] ?? 'assets/images/sample.png',
+                  )).toList(),
+                ),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, __) => const SizedBox(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/search/widgets/search_results_section.dart
+++ b/lib/features/search/widgets/search_results_section.dart
@@ -4,6 +4,8 @@ import 'package:plogo/features/search/providers/search_provider.dart';
 import 'package:plogo/shared/theme/app_colors.dart';
 import '../widgets/search_region_item.dart';
 import '../widgets/search_course_item.dart';
+import 'package:plogo/features/region/screens/sigungu_course_list_screen.dart';
+import 'package:plogo/features/detail/screens/course_detail_screen.dart';
 
 class SearchResultsSection extends ConsumerWidget {
   final String query;
@@ -20,10 +22,22 @@ class SearchResultsSection extends ConsumerWidget {
           data: (regions) => regions.isEmpty
               ? const SizedBox()
               : Column(
-                  children: regions.map((region) => SearchRegionItem(
-                    query: query,
-                    name: region['sigunguName'] ?? '',
-                    fullName: region['withArea'] ?? '',
+                  children: regions.map((region) => GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => SigunguCourseListScreen(
+                            regionName: region['sigunguName'] ?? '',
+                            sigunguId: region['sigunguId'],
+                          ),
+                        ),
+                      );
+                    },
+                    child: SearchRegionItem(
+                      query: query,
+                      name: region['sigunguName'] ?? '',
+                      fullName: region['withArea'] ?? '',
+                    ),
                   )).toList(),
                 ),
           loading: () => const Center(child: CircularProgressIndicator()),
@@ -45,11 +59,25 @@ class SearchResultsSection extends ConsumerWidget {
                   ),
                 )
               : Column(
-                  children: courses.map((course) => SearchCourseItem(
-                    query: query,
-                    name: course['name'] ?? '',
-                    address: course['area'] ?? '',
-                    iconPath: course['image'] ?? 'assets/images/sample.png',
+                  children: courses.map((course) => GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => CourseDetailScreen(
+                            courseId: course['course_id'],
+                            title: course['name'],
+                          ),
+                        ),
+                      );
+                    },
+                    child: SearchCourseItem(
+                      query: query,
+                      name: course['name'] ?? '',
+                      address: course['area'] ?? '',
+          iconPath: (course['image'] != null && course['image'].toString().isNotEmpty)
+            ? course['image']
+            : 'assets/images/no_image.png',
+                    ),
                   )).toList(),
                 ),
           loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/features/search/widgets/search_text_field.dart
+++ b/lib/features/search/widgets/search_text_field.dart
@@ -17,13 +17,21 @@ class SearchTextField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(24, 8, 20, 28),
+      padding: const EdgeInsets.fromLTRB(12, 8, 20, 28),
       child: Row(
         children: [
           IconButton(
             icon: const Icon(Icons.arrow_back_ios_new,
                 size: 28, color: AppColors.black),
-            onPressed: () => context.pop(),
+            onPressed: () {
+              if (controller.text.isNotEmpty) {
+                controller.clear();
+                onChanged();
+                focusNode.requestFocus();
+              } else {
+                context.pop();
+              }
+            },
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
           ),

--- a/lib/features/search/widgets/search_text_field.dart
+++ b/lib/features/search/widgets/search_text_field.dart
@@ -17,7 +17,7 @@ class SearchTextField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(12, 8, 20, 28),
+      padding: const EdgeInsets.fromLTRB(12, 8, 20, 18),
       child: Row(
         children: [
           IconButton(

--- a/lib/shared/widgets/course_list_view.dart
+++ b/lib/shared/widgets/course_list_view.dart
@@ -7,11 +7,13 @@ class CourseListView extends StatelessWidget {
   final String title;
   final List<CourseRecommendItem> courses;
   final Widget? topWidget;
+  final Function(int courseId, String name)? onCardTap;
   const CourseListView({
     super.key,
     required this.title,
     required this.courses,
     this.topWidget,
+    this.onCardTap,
   });
 
   @override
@@ -39,19 +41,21 @@ class CourseListView extends StatelessWidget {
                     final course = courses[i];
                     return GestureDetector(
                       onTap: () {
-                        // 상세페이지 이동
-                        // 현재 route에 따라 상세페이지 경로 결정
-                        final location =
-                            GoRouterState.of(context).matchedLocation;
-                        String detailRoute;
-                        if (location.startsWith('/log')) {
-                          detailRoute = '/log/detail/${course.courseId}';
-                        } else if (location.startsWith('/mypage')) {
-                          detailRoute = '/mypage/detail/${course.courseId}';
+                        if (onCardTap != null) {
+                          onCardTap!(course.courseId, course.name);
                         } else {
-                          detailRoute = '/home/detail/${course.courseId}';
+                          // 기존 상세페이지 이동 로직
+                          final location = GoRouterState.of(context).matchedLocation;
+                          String detailRoute;
+                          if (location.startsWith('/log')) {
+                            detailRoute = '/log/detail/${course.courseId}';
+                          } else if (location.startsWith('/mypage')) {
+                            detailRoute = '/mypage/detail/${course.courseId}';
+                          } else {
+                            detailRoute = '/home/detail/${course.courseId}';
+                          }
+                          context.push(detailRoute, extra: course.name);
                         }
-                        context.push(detailRoute, extra: course.name);
                       },
                       child: Padding(
                         padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 검색 기능 API 연동
- 검색 결과에 따라 리스트 및 상세페이지 띄우기
- 최근 검색어 불러오기 및 삭제, 업데이트

### 🤔 추후 작업 예정
- 검색 로직 문의 후 변동사항 있으면 수정(API 호출 시점, 화면 구성 등)
- 카카오맵

### 📸 작업 결과 (스크린샷)
<img width="425" height="916" alt="스크린샷 2025-11-23 오전 1 04 34" src="https://github.com/user-attachments/assets/d8a38953-ea97-4ba0-add5-a71ef91386f9" />


### 🔗 관련 이슈
- close: #11 